### PR TITLE
Fixed a few bugs that prevented encryption and decryption

### DIFF
--- a/lib/symmetric.ts
+++ b/lib/symmetric.ts
@@ -17,7 +17,7 @@ const PREFIX_COMMIT_KEY = new Uint8Array([
  */
 export interface SymmetricEncryptionInterface {
     encrypt(
-        message: string|Buffer,
+        message: string | Buffer,
         key: CryptographyKey,
         assocData?: string
     ): Promise<string>;
@@ -25,7 +25,7 @@ export interface SymmetricEncryptionInterface {
         message: string,
         key: CryptographyKey,
         assocData?: string
-    ): Promise<string|Buffer>;
+    ): Promise<string | Buffer>;
 }
 
 /**
@@ -33,7 +33,7 @@ export interface SymmetricEncryptionInterface {
  */
 export class SymmetricCrypto implements SymmetricEncryptionInterface {
     async encrypt(
-        message: string|Buffer,
+        message: string | Buffer,
         key: CryptographyKey,
         assocData?: string
     ): Promise<string> {
@@ -43,7 +43,7 @@ export class SymmetricCrypto implements SymmetricEncryptionInterface {
         message: string,
         key: CryptographyKey,
         assocData?: string
-    ): Promise<string|Buffer> {
+    ): Promise<string | Buffer> {
         return decryptData(message, key, assocData);
     }
 }
@@ -57,7 +57,7 @@ export type KeyDerivationFunction = (ikm: Uint8Array, salt?: Uint8Array, info?: 
  * @param {Uint8Array} nonce
  * @returns {{encKey: CryptographyKey, commitment: Uint8Array}}
  */
-export async function deriveKeys(key, nonce) {
+export async function deriveKeys(key: CryptographyKey, nonce: Uint8Array): Promise<{ encKey: CryptographyKey; commitment: Uint8Array; }> {
     if (!sodium) sodium = await SodiumPlus.auto();
 
     const encKey = new CryptographyKey(await sodium.crypto_generichash(
@@ -70,7 +70,7 @@ export async function deriveKeys(key, nonce) {
         key,
         32
     );
-    return {encKey, commitment};
+    return { encKey, commitment };
 }
 
 /**
@@ -83,7 +83,7 @@ export async function deriveKeys(key, nonce) {
  * @returns {string}
  */
 export async function encryptData(
-    message: string|Buffer,
+    message: string | Buffer,
     key: CryptographyKey,
     assocData?: string
 ): Promise<string> {
@@ -96,7 +96,7 @@ export async function encryptData(
         'nonce': await sodium.sodium_bin2hex(nonce),
         'extra': assocData
     });
-    const {encKey, commitment} = await deriveKeys(key, nonce);
+    const { encKey, commitment } = await deriveKeys(key, nonce);
     const encrypted = await sodium.crypto_aead_xchacha20poly1305_ietf_encrypt(
         message,
         nonce,
@@ -124,10 +124,9 @@ export async function decryptData(
     encrypted: string,
     key: CryptographyKey,
     assocData?: string
-): Promise<string|Buffer> {
+): Promise<string | Buffer> {
     // Load libsodium
     if (!sodium) sodium = await SodiumPlus.auto();
-
     const ver = Buffer.from(encrypted.slice(0, 2), 'utf-8');
     if (!await sodium.sodium_memcmp(ver, VERSION_BUF)) {
         throw new Error("Incorrect version: " + encrypted.slice(0, 2));
@@ -140,7 +139,7 @@ export async function decryptData(
         'extra': assocData
     });
     const storedCommitment = await sodium.sodium_hex2bin(encrypted.slice(50, 114));
-    const {encKey, commitment} = await deriveKeys(key, nonce);
+    const { encKey, commitment } = await deriveKeys(key, nonce);
     if (!(await sodium.sodium_memcmp(storedCommitment, commitment))) {
         throw new Error("Incorrect commitment value");
     }
@@ -161,7 +160,7 @@ export async function decryptData(
  */
 export async function blakeKdf(
     ikm: Uint8Array,
-    salt?: Uint8Array|CryptographyKey,
+    salt?: Uint8Array | CryptographyKey,
     info?: Uint8Array
 ): Promise<Uint8Array> {
     if (!sodium) sodium = await SodiumPlus.auto();

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -51,10 +51,11 @@ export async function generateKeyPair(): Promise<Keypair> {
  * @returns {Keypair[]}
  */
 export async function generateBundle(preKeyCount: number = 100): Promise<Keypair[]> {
-    const bundle = [];
+    const bundle: Keypair[] = [];
     for (let i = 0; i < preKeyCount; i++) {
         bundle.push(await generateKeyPair());
     }
+        
     return bundle;
 }
 


### PR DESCRIPTION
First of all, thank you for your awesome work with the library. We are currently trying to build an end to end encrypted document collaboration system much like google docs but with end to end encryption. I am looking into the encryption part and as such have been working with your library for the past few days. Initially there were few bugs that hindered encryption/decryption and as such I have tried fixing them.
Bugs fixed: 
- Most of them were type errors that were fixed by explicitly defining the types or using type:any wherever required.
- Added a code block that stored the X25119 keypair in the object because the private part was necessary during the shared key calculation process, wrote a function for that and added the function declaration in the exported IdentityKeyManager interface.
- The function “saveIdentityKeyPair” wasn’t exported and as such wasn’t being used, so added the function signature to the exported interface.
- Removed the slice function that was being used with the buffer types(since it is deprecated) and used the subarray function in its place.
- The function “saveIdentityKeypair” was only saving the private part of the identity key, edited it to save both the public and private part.

Right now, the library is working correctly with the encryption and decryption.
Please checkout the changes and merge the ones you deem fit. 

